### PR TITLE
update spring milestone repository to use https instead of http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -448,7 +448,7 @@
         <repository>
             <id>repository.spring.milestone</id>
             <name>Spring Milestone Repository</name>
-            <url>http://repo.spring.io/milestone</url>
+            <url>https://repo.spring.io/milestone</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
http repositories are broken in Maven 3.6.3, this change fixes that issue.